### PR TITLE
feature: GameOldInformationBar

### DIFF
--- a/modules/gamelib/const.lua
+++ b/modules/gamelib/const.lua
@@ -196,6 +196,8 @@ GameDrawAuraOnTop = 109
 GamePacketSizeU32 = 110
 GamePacketCompression = 111
 
+GameOldInformationBar = 112
+
 LastGameFeature = 130
         
 TextColors = {

--- a/src/client/const.h
+++ b/src/client/const.h
@@ -469,6 +469,9 @@ namespace Otc
         GamePacketSizeU32 = 110,
         GamePacketCompression = 111,
 
+        // OTCv8-dev features
+        GameOldInformationBar = 112,
+
         LastGameFeature = 130
     };
 

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -131,8 +131,10 @@ void Creature::drawOutfit(const Rect& destRect, Otc::Direction direction, const 
 
 void Creature::drawInformation(const Point& point, bool useGray, const Rect& parentRect, int drawFlags)
 {
-    if (m_healthPercent < 1) // creature is dead
-        return;
+    if (!g_game.getFeature(Otc::GameOldInformationBar) && g_game.getClientVersion() >= 760) {
+        if (m_healthPercent < 1)  // creature is dead, we get rid of its information bar
+            return;
+    }
 
     Color fillColor = Color(96, 96, 96);
 
@@ -610,7 +612,7 @@ void Creature::setHealthPercent(uint8 healthPercent)
         else if (healthPercent > 3)
             m_informationColor = Color(0x91, 0x0F, 0x0F);
         else
-            m_informationColor = Color(0x85, 0x0C, 0x0C);
+            m_informationColor = Color(0x2C, 0x0F, 0x0F);
     }
 
     bool changed = m_healthPercent != healthPercent;


### PR DESCRIPTION
Introduction of pre 7.6 behavior of creatures information (health) bar.
This PR also tweaks the color of the bar below 3% to match the RL Tibia client.

![healthbar](https://user-images.githubusercontent.com/51740363/108886946-e1cca300-7609-11eb-9b16-04c4c55f9f88.gif)



