### PR TITLE
Wing offset

### DIFF
--- a/modules/gamelib/const.lua
+++ b/modules/gamelib/const.lua
@@ -198,6 +198,7 @@ GamePacketCompression = 111
 
 GameOldInformationBar = 112
 GameHealthInfoBackground = 113
+GameWingOffset = 114
 
 LastGameFeature = 130
         

--- a/src/client/const.h
+++ b/src/client/const.h
@@ -472,6 +472,7 @@ namespace Otc
         // OTCv8-dev features
         GameOldInformationBar = 112,
         GameHealthInfoBackground = 113,
+        GameWingOffset = 114,
 
         LastGameFeature = 130
     };

--- a/src/client/outfit.cpp
+++ b/src/client/outfit.cpp
@@ -51,6 +51,10 @@ void Outfit::draw(Point dest, Otc::Direction direction, uint walkAnimationPhase,
     else if (direction == Otc::NorthWest || direction == Otc::SouthWest)
         direction = Otc::West;
 
+    Point wingDest = dest;
+    if(g_game.getFeature(Otc::GameWingOffset) && m_wings)
+        dest -= Point(6, 6);
+
     auto type = g_things.rawGetThingType(m_category == ThingCategoryCreature ? m_id : m_auxId, m_category);
     if (!type) return;
     int animationPhase = walkAnimationPhase;
@@ -120,7 +124,7 @@ void Outfit::draw(Point dest, Otc::Direction direction, uint walkAnimationPhase,
                 wingAnimationPhase = (g_clock.millis() % (ticksPerFrame * phases)) / ticksPerFrame;
             }
         }
-        wingsType->draw(dest, 0, direction, 0, wingsZPattern, wingAnimationPhase, Color::white, lightView);
+        wingsType->draw(wingDest, 0, direction, 0, wingsZPattern, wingAnimationPhase, Color::white, lightView);
     };
 
     auto drawAura = [&] {
@@ -184,6 +188,9 @@ void Outfit::draw(Point dest, Otc::Direction direction, uint walkAnimationPhase,
     }
 
     if (m_wings && (direction == Otc::North || direction == Otc::West)) {
+        if (g_game.getFeature(Otc::GameWingOffset) && zPattern > 0)
+            wingDest += Point(4, 6);
+
         drawWings();
     }
 

--- a/src/client/outfit.cpp
+++ b/src/client/outfit.cpp
@@ -147,6 +147,12 @@ void Outfit::draw(Point dest, Otc::Direction direction, uint walkAnimationPhase,
     }
 
     if (m_wings && (direction == Otc::South || direction == Otc::East)) {
+        if (g_game.getFeature(Otc::GameWingOffset) && zPattern > 0) {
+            if (direction == Otc::East)
+                wingDest -= Point(6, 2);
+            else
+                wingDest -= Point(0, 6);
+        }
         drawWings();
     }
 

--- a/src/client/outfit.cpp
+++ b/src/client/outfit.cpp
@@ -65,9 +65,6 @@ void Outfit::draw(Point dest, Otc::Direction direction, uint walkAnimationPhase,
         int tick = (g_clock.millis() % (1000)) / (1000 / floatingTicks);
         int offset = 0;
         if (walkAnimationPhase > 0) {
-            offset = walkAnimationPhase <= floatingTicks / 2 ? walkAnimationPhase * (maxoffset / (floatingTicks / 2)) : (2 * maxoffset) - walkAnimationPhase * (maxoffset / (floatingTicks / 2));
-            dest -= Point(offset, offset);
-            wingDest -= Point(offset, offset);
             auto idleAnimator = type->getIdleAnimator();
             if (idleAnimator) {
                 animationPhase = idleAnimator->getPhase();
@@ -76,11 +73,9 @@ void Outfit::draw(Point dest, Otc::Direction direction, uint walkAnimationPhase,
                 animationPhase = 0;
             }
         }
-        else {
-            offset = tick <= floatingTicks / 2 ? tick * (maxoffset / (floatingTicks / 2)) : (2 * maxoffset) - tick * (maxoffset / (floatingTicks / 2));
-            dest -= Point(offset, offset);
-            wingDest -= Point(offset, offset);
-        }
+        offset = tick <= floatingTicks / 2 ? tick * (maxoffset / (floatingTicks / 2)) : (2 * maxoffset) - tick * (maxoffset / (floatingTicks / 2));
+        dest -= Point(offset, offset);
+        wingDest -= Point(offset, offset);
     };
 
     if (animate && m_category == ThingCategoryCreature) {


### PR DESCRIPTION
Implemented a character offset when using wings, so it seems to be 'flying' and on mounts too. Also this make it easier to implement wings on object builder. Enabled/disabled with feature GameWingOffset.
Disabled:
![without](https://user-images.githubusercontent.com/52679827/114470666-a8ee8a80-9bc5-11eb-8fc3-c06eb3f93173.gif)
Enabled:
![with](https://user-images.githubusercontent.com/52679827/114470683-aee46b80-9bc5-11eb-966c-015f7265a7dc.gif)
