### PR TITLE
gameAuraFrontAndBack

### DIFF
--- a/modules/gamelib/const.lua
+++ b/modules/gamelib/const.lua
@@ -199,7 +199,7 @@ GamePacketCompression = 111
 GameOldInformationBar = 112
 GameHealthInfoBackground = 113
 GameWingOffset = 114
-GameAuraFrontAndBack = 115 -- To use that, make the Back aura as idle and the front aura as walking in object builder
+GameAuraFrontAndBack = 115 -- To use that: First layer is bottom/back, second (blend layer) is top/front
 
 LastGameFeature = 130
         

--- a/modules/gamelib/const.lua
+++ b/modules/gamelib/const.lua
@@ -199,6 +199,7 @@ GamePacketCompression = 111
 GameOldInformationBar = 112
 GameHealthInfoBackground = 113
 GameWingOffset = 114
+GameAuraFrontAndBack = 115 -- To use that, make the Back aura as idle and the front aura as walking in object builder
 
 LastGameFeature = 130
         

--- a/src/client/const.h
+++ b/src/client/const.h
@@ -471,8 +471,9 @@ namespace Otc
 
         // OTCv8-dev features
         GameOldInformationBar = 112,
-        GameHealthInfoBackground = 113,
+        GameHealthInfoBackground = 113, 
         GameWingOffset = 114,
+        GameAuraFrontAndBack = 115,
 
         LastGameFeature = 130
     };

--- a/src/client/outfit.cpp
+++ b/src/client/outfit.cpp
@@ -151,11 +151,16 @@ void Outfit::draw(Point dest, Otc::Direction direction, uint walkAnimationPhase,
     auto drawTopAura = [&] {
         int auraAnimationPhase = 0;
         auto auraType = g_things.rawGetThingType(m_aura, ThingCategoryCreature);
-        auto idleAnimator = auraType->getIdleAnimator();
-        if (idleAnimator) {
-            auraAnimationPhase = idleAnimator->getPhase() + idleAnimator->getAnimationPhases();
+        auto auraAnimator = auraType->getAnimator();
+        if (animate) {
+            if (auraAnimator) {
+                auraAnimationPhase = auraAnimator->getPhase();
+            }
+            else {
+                auraAnimationPhase = (stdext::millis() / 75) % auraType->getAnimationPhases();
+            }
         }
-        auraType->draw(topAuraDest, 0, direction, 0, 0, auraAnimationPhase, Color::white, lightView);
+        auraType->draw(topAuraDest, 1, direction, 0, 0, auraAnimationPhase, Color::white, lightView);
     };
 
     if (m_aura && (!g_game.getFeature(Otc::GameDrawAuraOnTop) or g_game.getFeature(Otc::GameAuraFrontAndBack)) ) {


### PR DESCRIPTION
In this PR it makes possible to use 2 layers of an aura, by setting the back (or bottom) layer as idle and the front (or top) layer as walking in object builder.
Example of how it looks:
![aura](https://user-images.githubusercontent.com/52679827/114888346-85069100-9ddf-11eb-88cc-f2d829128975.gif)
It also fixes the aura being always placed on top of mounts

Edit: Now instead of idle/walking, the layers are actually from layers at the object builder