### PR TITLE
replaced getClientVersion with getProtocolVersion

### DIFF
--- a/modules/game_market/marketprotocol.lua
+++ b/modules/game_market/marketprotocol.lua
@@ -56,8 +56,8 @@ local function parseMarketEnter(protocol, msg)
   end
   
   local balance = 0
-  if g_game.getClientVersion() <= 1250 or not g_game.getFeature(GameTibia12Protocol) then
-    if g_game.getClientVersion() >= 981 or g_game.getClientVersion() < 944 then
+  if g_game.getProtocolVersion() <= 1250 or not g_game.getFeature(GameTibia12Protocol) then
+    if g_game.getProtocolVersion() >= 981 or g_game.getProtocolVersion() < 944 then
       balance = msg:getU64()
     else
       balance = msg:getU32()
@@ -65,7 +65,7 @@ local function parseMarketEnter(protocol, msg)
   end
   
   local vocation = -1
-  if g_game.getClientVersion() >= 944 and g_game.getClientVersion() < 950 then
+  if g_game.getProtocolVersion() >= 944 and g_game.getProtocolVersion() < 950 then
     vocation = msg:getU8() -- get vocation id
   end
   local offers = msg:getU8()
@@ -100,7 +100,7 @@ local function parseMarketDetail(protocol, msg)
     end
   end
 
-  if g_game.getClientVersion() >= 1100 then -- imbuements
+  if g_game.getProtocolVersion() >= 1100 then -- imbuements
     if msg:peekU16() ~= 0x00 then
       table.insert(descriptions, {MarketItemDescription.Last + 1, msg:getString()})
     else

--- a/modules/game_protocol/protocol.lua
+++ b/modules/game_protocol/protocol.lua
@@ -124,7 +124,7 @@ function registerProtocol()
 
   registerOpcode(ServerPackets.Inspection, function(protocol, msg)
 	local bool = msg:getU8() -- IsPlayer
-	if g_game.getClientVersion() >= 1230 then
+	if g_game.getProtocolVersion() >= 1230 then
 		msg:getU8()
 	end
 	local size = msg:getU8() -- List
@@ -209,7 +209,7 @@ function registerProtocol()
 
   registerOpcode(ServerPackets.CyclopediaCharacterInfo, function(protocol, msg)
 	local type = msg:getU8()
-	if g_game.getClientVersion() >= 1215 then
+	if g_game.getProtocolVersion() >= 1215 then
 		local error = msg:getU8()
 		if error > 0 then
 			-- [1] 'No data available at the moment.'
@@ -232,7 +232,7 @@ function registerProtocol()
 			msg:getU16() -- lookTypeEx
 		end
 		msg:getU8() -- Hide stamina
-		if g_game.getClientVersion() >= 1220 then
+		if g_game.getProtocolVersion() >= 1220 then
 			msg:getU8() -- Personal habs
 			msg:getString() -- Title
 		end
@@ -268,7 +268,7 @@ function registerProtocol()
 			msg:getU16() -- Base skill
 			msg:getU16() -- Skill percent
 		end
-		if g_game.getClientVersion() < 1215 then
+		if g_game.getProtocolVersion() < 1215 then
 			msg:getU16()
 			msg:getString() -- Player name
 			msg:getString() -- Vocation
@@ -369,7 +369,7 @@ function registerProtocol()
 			msg:getU8() -- Category 0 = Standard, 1 = Quest, 2 = Store
 			msg:getU32() -- Is current ? then 1000 or 0
 		end
-		if g_game.getClientVersion() >= 1260 then
+		if g_game.getProtocolVersion() >= 1260 then
 			msg:getU8() -- Mount lookHead
 			msg:getU8() -- Mount lookBody
 			msg:getU8() -- Mount lookLegs
@@ -532,7 +532,7 @@ function registerProtocol()
 	msg:getU8() -- Is updating
 	msg:getU32() -- Normal coin
 	msg:getU32() -- Transferable coin
-	if g_game.getClientVersion() >= 1220 then
+	if g_game.getProtocolVersion() >= 1220 then
 		msg:getU32() -- Reserved auction coin
 		msg:getU32() -- Tournament coin
 	end
@@ -652,17 +652,17 @@ end
 function readAddItem(msg)
 	msg:getU16() -- Item client ID
  
-	if g_game.getClientVersion() < 1150 then
+	if g_game.getProtocolVersion() < 1150 then
 		msg:getU8() -- Unmarked
 	end
 
 	local var = msg:getU8()
-	if g_game.getClientVersion() > 1150 then
+	if g_game.getProtocolVersion() > 1150 then
 		if var == 1 then
 			msg:getU32() -- Loot flag
 		end
 
-		if g_game.getClientVersion() >= 1260 then
+		if g_game.getProtocolVersion() >= 1260 then
 			local isQuiver = msg:getU8()
 			if isQuiver == 1 then
 				msg:getU32() -- Quiver count

--- a/modules/gamelib/protocollogin.lua
+++ b/modules/gamelib/protocollogin.lua
@@ -110,7 +110,7 @@ function ProtocolLogin:sendLoginPacket()
     msg:addU8(1) --unknown
     msg:addU8(1) --unknown
 
-    if g_game.getClientVersion() >= 1072 then
+    if g_game.getProtocolVersion() >= 1072 then
       msg:addString(string.format('%s %s', g_graphics.getVendor(), g_graphics.getRenderer()))
     else
       msg:addString(g_graphics.getRenderer())
@@ -221,7 +221,7 @@ end
 function ProtocolLogin:parseCharacterList(msg)
   local characters = {}
 
-  if g_game.getClientVersion() > 1010 then
+  if g_game.getProtocolVersion() > 1010 then
     local worlds = {}
 
     local worldsCount = msg:getU8()

--- a/src/client/protocolgameparse.cpp
+++ b/src/client/protocolgameparse.cpp
@@ -597,10 +597,10 @@ void ProtocolGame::parseLogin(const InputMessagePtr& msg)
     }
     bool canReportBugs = msg->getU8();
 
-    if (g_game.getClientVersion() >= 1054)
+    if (g_game.getProtocolVersion() >= 1054)
         msg->getU8(); // can change pvp frame option
 
-    if (g_game.getClientVersion() >= 1058) {
+    if (g_game.getProtocolVersion() >= 1058) {
         int expertModeEnabled = msg->getU8();
         g_game.setExpertPvpMode(expertModeEnabled);
     }
@@ -765,7 +765,7 @@ void ProtocolGame::parseStoreTransactionHistory(const InputMessagePtr& msg)
 {
     int currentPage;
     bool hasNextPage;
-    if (g_game.getClientVersion() <= 1096) {
+    if (g_game.getProtocolVersion() <= 1096) {
         currentPage = msg->getU16();
         hasNextPage = msg->getU8() == 1;
     } else {
@@ -835,7 +835,7 @@ void ProtocolGame::parseStoreOffers(const InputMessagePtr& msg)
                         msg->getString(); // error msg
                 }
                 offer.state = msg->getU8();
-                if (offer.state == 2 && g_game.getFeature(Otc::GameIngameStoreHighlights) && g_game.getClientVersion() >= 1097) {
+                if (offer.state == 2 && g_game.getFeature(Otc::GameIngameStoreHighlights) && g_game.getProtocolVersion() >= 1097) {
                     /*int saleValidUntilTimestamp = */msg->getU32();
                     /*int basePrice = */msg->getU32();
                 }
@@ -864,7 +864,7 @@ void ProtocolGame::parseStoreOffers(const InputMessagePtr& msg)
 
             offer.price = msg->getU32();
             offer.state = msg->getU8();
-            if (offer.state == 2 && g_game.getFeature(Otc::GameIngameStoreHighlights) && g_game.getClientVersion() >= 1097) {
+            if (offer.state == 2 && g_game.getFeature(Otc::GameIngameStoreHighlights) && g_game.getProtocolVersion() >= 1097) {
                 /*int saleValidUntilTimestamp = */msg->getU32();
                 /*int basePrice = */msg->getU32();
             }
@@ -980,9 +980,9 @@ void ProtocolGame::parseGMActions(const InputMessagePtr& msg)
 
     int numViolationReasons;
 
-    if (g_game.getClientVersion() >= 850)
+    if (g_game.getProtocolVersion() >= 850)
         numViolationReasons = 20;
-    else if (g_game.getClientVersion() >= 840)
+    else if (g_game.getProtocolVersion() >= 840)
         numViolationReasons = 23;
     else
         numViolationReasons = 32;
@@ -1354,7 +1354,7 @@ void ProtocolGame::parseOpenNpcTrade(const InputMessagePtr& msg)
 
     int listCount;
 
-    if (g_game.getClientVersion() >= 986) // tbh not sure from what version
+    if (g_game.getProtocolVersion() >= 986) // tbh not sure from what version
         listCount = msg->getU16();
     else
         listCount = msg->getU8();
@@ -1448,7 +1448,7 @@ void ProtocolGame::parseWorldLight(const InputMessagePtr& msg)
 void ProtocolGame::parseMagicEffect(const InputMessagePtr& msg)
 {
     Position pos = getPosition(msg);
-    if (g_game.getFeature(Otc::GameTibia12Protocol) && g_game.getClientVersion() >= 1203) {
+    if (g_game.getFeature(Otc::GameTibia12Protocol) && g_game.getProtocolVersion() >= 1203) {
         Otc::MagicEffectsType_t effectType = (Otc::MagicEffectsType_t)msg->getU8();
         while (effectType != Otc::MAGIC_EFFECTS_END_LOOP) {
             if (effectType == Otc::MAGIC_EFFECTS_DELTA) {
@@ -1623,7 +1623,7 @@ void ProtocolGame::parseCreatureSpeed(const InputMessagePtr& msg)
     uint id = msg->getU32();
 
     int baseSpeed = -1;
-    if (g_game.getClientVersion() >= 1059)
+    if (g_game.getProtocolVersion() >= 1059)
         baseSpeed = msg->getU16();
 
     int speed = msg->getU16();
@@ -1684,7 +1684,7 @@ void ProtocolGame::parseEditText(const InputMessagePtr& msg)
     uint id = msg->getU32();
 
     int itemId;
-    if (g_game.getClientVersion() >= 1010) {
+    if (g_game.getProtocolVersion() >= 1010) {
         // TODO: processEditText with ItemPtr as parameter
         ItemPtr item = getItem(msg);
         itemId = item->getId();
@@ -1723,7 +1723,7 @@ void ProtocolGame::parsePremiumTrigger(const InputMessagePtr& msg)
         triggers.push_back(msg->getU8());
     }
 
-    if (g_game.getClientVersion() <= 1096) {
+    if (g_game.getProtocolVersion() <= 1096) {
         /*bool something = */msg->getU8()/* == 1*/;
     }
 }
@@ -1750,11 +1750,11 @@ void ProtocolGame::parsePreyData(const InputMessagePtr& msg)
     Otc::PreyState_t state = (Otc::PreyState_t)msg->getU8();
     if (state == Otc::PREY_STATE_LOCKED) {
         Otc::PreyUnlockState_t unlockState = (Otc::PreyUnlockState_t)msg->getU8();
-        int timeUntilFreeReroll = g_game.getClientVersion() >= 1252 ? msg->getU32() : msg->getU16();
+        int timeUntilFreeReroll = g_game.getProtocolVersion() >= 1252 ? msg->getU32() : msg->getU16();
         uint8_t lockType = g_game.getFeature(Otc::GameTibia12Protocol) ? msg->getU8() : 0;
         return g_lua.callGlobalField("g_game", "onPreyLocked", slot, unlockState, timeUntilFreeReroll, lockType);
     } else if (state == Otc::PREY_STATE_INACTIVE) {
-        int timeUntilFreeReroll = g_game.getClientVersion() >= 1252 ? msg->getU32() : msg->getU16();
+        int timeUntilFreeReroll = g_game.getProtocolVersion() >= 1252 ? msg->getU32() : msg->getU16();
         uint8_t lockType = g_game.getFeature(Otc::GameTibia12Protocol) ? msg->getU8() : 0;
         return g_lua.callGlobalField("g_game", "onPreyInactive", slot, timeUntilFreeReroll, lockType);
     } else if (state == Otc::PREY_STATE_ACTIVE) {
@@ -1764,7 +1764,7 @@ void ProtocolGame::parsePreyData(const InputMessagePtr& msg)
         int bonusValue = msg->getU16();
         int bonusGrade = msg->getU8();
         int timeLeft = msg->getU16();
-        int timeUntilFreeReroll = g_game.getClientVersion() >= 1252 ? msg->getU32() : msg->getU16();
+        int timeUntilFreeReroll = g_game.getProtocolVersion() >= 1252 ? msg->getU32() : msg->getU16();
         uint8_t lockType = g_game.getFeature(Otc::GameTibia12Protocol) ? msg->getU8() : 0;
         return g_lua.callGlobalField("g_game", "onPreyActive", slot, currentHolderName, currentHolderOutfit, bonusType, bonusValue, bonusGrade, timeLeft, timeUntilFreeReroll, lockType);
     } else if (state == Otc::PREY_STATE_SELECTION || state == Otc::PREY_STATE_SELECTION_CHANGE_MONSTER) {
@@ -1782,7 +1782,7 @@ void ProtocolGame::parsePreyData(const InputMessagePtr& msg)
             names.push_back(msg->getString());
             outfits.push_back(getOutfit(msg, true));
         }
-        int timeUntilFreeReroll = g_game.getClientVersion() >= 1252 ? msg->getU32() : msg->getU16();
+        int timeUntilFreeReroll = g_game.getProtocolVersion() >= 1252 ? msg->getU32() : msg->getU16();
         uint8_t lockType = g_game.getFeature(Otc::GameTibia12Protocol) ? msg->getU8() : 0;
         return g_lua.callGlobalField("g_game", "onPreySelection", slot, bonusType, bonusValue, bonusGrade, names, outfits, timeUntilFreeReroll, lockType);
     } else if (state == Otc::PREY_ACTION_CHANGE_FROM_ALL) {
@@ -1794,7 +1794,7 @@ void ProtocolGame::parsePreyData(const InputMessagePtr& msg)
         for (int i = 0; i < count; ++i) {
             races.push_back(msg->getU16());
         }
-        int timeUntilFreeReroll = g_game.getClientVersion() >= 1252 ? msg->getU32() : msg->getU16();
+        int timeUntilFreeReroll = g_game.getProtocolVersion() >= 1252 ? msg->getU32() : msg->getU16();
         uint8_t lockType = g_game.getFeature(Otc::GameTibia12Protocol) ? msg->getU8() : 0;
         return g_lua.callGlobalField("g_game", "onPreyChangeFromAll", slot, bonusType, bonusValue, bonusGrade, races, timeUntilFreeReroll, lockType);
     } else if (state == Otc::PREY_STATE_SELECTION_FROMALL) {
@@ -1803,7 +1803,7 @@ void ProtocolGame::parsePreyData(const InputMessagePtr& msg)
         for (int i = 0; i < count; ++i) {
             races.push_back(msg->getU16());
         }
-        int timeUntilFreeReroll = g_game.getClientVersion() >= 1252 ? msg->getU32() : msg->getU16();
+        int timeUntilFreeReroll = g_game.getProtocolVersion() >= 1252 ? msg->getU32() : msg->getU16();
         uint8_t lockType = g_game.getFeature(Otc::GameTibia12Protocol) ? msg->getU8() : 0;
         return g_lua.callGlobalField("g_game", "onPreyChangeFromAll", slot, races, timeUntilFreeReroll, lockType);
     } else {
@@ -1895,7 +1895,7 @@ void ProtocolGame::parsePlayerStats(const InputMessagePtr& msg)
     double levelPercent = msg->getU8();
 
     if (g_game.getFeature(Otc::GameExperienceBonus)) {
-        if (g_game.getClientVersion() <= 1096) {
+        if (g_game.getProtocolVersion() <= 1096) {
             /*double experienceBonus = */msg->getDouble();
         } else {
             /*int baseXpGain = */msg->getU16();
@@ -1960,7 +1960,7 @@ void ProtocolGame::parsePlayerStats(const InputMessagePtr& msg)
     double training = 0;
     if (g_game.getFeature(Otc::GameOfflineTrainingTime)) {
         training = msg->getU16();
-        if (g_game.getClientVersion() >= 1097) {
+        if (g_game.getProtocolVersion() >= 1097) {
             /*int remainingStoreXpBoostSeconds = */msg->getU16();
             /*bool canBuyMoreStoreXpBoosts = */msg->getU8();
         }
@@ -2745,7 +2745,7 @@ void ProtocolGame::parseModalDialog(const InputMessagePtr& msg)
     }
 
     int enterButton, escapeButton;
-    if (g_game.getClientVersion() > 970) {
+    if (g_game.getProtocolVersion() > 970) {
         escapeButton = msg->getU8();
         enterButton = msg->getU8();
     } else {
@@ -2785,7 +2785,7 @@ void ProtocolGame::parseBlessDialog(const InputMessagePtr& msg)
     for (int i = 0; i < totalBless; i++) {
         msg->getU16(); // bless bit wise
         msg->getU8(); // player bless count
-        if (g_game.getClientVersion() >= 1220) {
+        if (g_game.getProtocolVersion() >= 1220) {
             msg->getU8(); // store?
         }
     }
@@ -3104,7 +3104,7 @@ void ProtocolGame::parseFeatures(const InputMessagePtr& msg)
 void ProtocolGame::parseCreaturesMark(const InputMessagePtr& msg)
 {
     int len;
-    if (g_game.getClientVersion() >= 1035) {
+    if (g_game.getProtocolVersion() >= 1035) {
         len = 1;
     } else {
         len = msg->getU8();
@@ -3375,11 +3375,11 @@ CreaturePtr ProtocolGame::getCreature(const InputMessagePtr& msg, int type)
                 g_map.removeCreatureById(removeId);
             }
 
-            if (g_game.getFeature(Otc::GameTibia12Protocol) && g_game.getClientVersion() >= 1252)
+            if (g_game.getFeature(Otc::GameTibia12Protocol) && g_game.getProtocolVersion() >= 1252)
                 msg->getU8();
 
             int creatureType;
-            if (g_game.getClientVersion() >= 910)
+            if (g_game.getProtocolVersion() >= 910)
                 creatureType = msg->getU8();
             else {
                 if (id >= Proto::PlayerStartId && id < Proto::PlayerEndId)
@@ -3433,7 +3433,7 @@ CreaturePtr ProtocolGame::getCreature(const InputMessagePtr& msg, int type)
         light.color = msg->getU8();
 
         int speed = msg->getU16();
-        if (g_game.getFeature(Otc::GameTibia12Protocol) && g_game.getClientVersion() >= 1240)
+        if (g_game.getFeature(Otc::GameTibia12Protocol) && g_game.getProtocolVersion() >= 1240)
             msg->getU8();
         int skull = msg->getU8();
         int shield = msg->getU8();
@@ -3453,7 +3453,7 @@ CreaturePtr ProtocolGame::getCreature(const InputMessagePtr& msg, int type)
             if (g_game.getFeature(Otc::GameTibia12Protocol)) {
                 if (creatureType == Proto::CreatureTypeSummonOwn)
                     msg->getU32(); // master
-                if (g_game.getClientVersion() >= 1215 && creatureType == Proto::CreatureTypePlayer)
+                if (g_game.getProtocolVersion() >= 1215 && creatureType == Proto::CreatureTypePlayer)
                     msg->getU8(); // vocation id
             }
         }
@@ -3477,7 +3477,7 @@ CreaturePtr ProtocolGame::getCreature(const InputMessagePtr& msg, int type)
             }
         }
 
-        if (g_game.getClientVersion() >= 854 || g_game.getFeature(Otc::GameCreatureWalkthrough))
+        if (g_game.getProtocolVersion() >= 854 || g_game.getFeature(Otc::GameCreatureWalkthrough))
             unpass = msg->getU8();
 
         if (creature) {
@@ -3516,7 +3516,7 @@ CreaturePtr ProtocolGame::getCreature(const InputMessagePtr& msg, int type)
             }
         }
 
-        if (g_game.getClientVersion() >= 953 || g_game.getFeature(Otc::GameCreatureDirectionPassable)) {
+        if (g_game.getProtocolVersion() >= 953 || g_game.getFeature(Otc::GameCreatureDirectionPassable)) {
             bool unpass = msg->getU8();
 
             if (creature)

--- a/src/client/protocolgamesend.cpp
+++ b/src/client/protocolgamesend.cpp
@@ -760,7 +760,7 @@ void ProtocolGame::sendShareExperience(bool active)
     OutputMessagePtr msg(new OutputMessage);
     msg->addU8(Proto::ClientShareExperience);
     msg->addU8(active ? 0x01 : 0x00);
-    if(g_game.getClientVersion() < 910)
+    if(g_game.getProtocolVersion() < 910)
         msg->addU8(0);
     send(msg);
 }
@@ -815,7 +815,7 @@ void ProtocolGame::sendChangeOutfit(const Outfit& outfit)
     OutputMessagePtr msg(new OutputMessage);
     msg->addU8(Proto::ClientChangeOutfit);
 
-    if (g_game.getFeature(Otc::GameTibia12Protocol) && g_game.getClientVersion() >= 1220) {
+    if (g_game.getFeature(Otc::GameTibia12Protocol) && g_game.getProtocolVersion() >= 1220) {
         msg->addU8(0); // outfit type
     }
 
@@ -925,7 +925,7 @@ void ProtocolGame::sendBugReport(const std::string& comment)
 {
     OutputMessagePtr msg(new OutputMessage);
     msg->addU8(Proto::ClientBugReport);
-    if (g_game.getClientVersion() > 1000) {
+    if (g_game.getProtocolVersion() > 1000) {
         msg->addU8(3); // other
     }
     msg->addString(comment);
@@ -1044,7 +1044,7 @@ void ProtocolGame::sendRequestTransactionHistory(int page, int entriesPerPage)
 {
     OutputMessagePtr msg(new OutputMessage);
     msg->addU8(Proto::ClientRequestTransactionHistory);
-    if(g_game.getClientVersion() <= 1096) {
+    if(g_game.getProtocolVersion() <= 1096) {
         msg->addU16(page);
         msg->addU32(entriesPerPage);
     } else {


### PR DESCRIPTION
Replaces the getClientVersion method to getProtocolVersion to facilitate the use of a different SPR version than the Protocol version, so it will be possible to use a TFS with version 10.98 using an SPR with version 10.41 without having problems with the protocol.