### PR TITLE
fix: Stutter while walking

### DIFF
--- a/modules/gamelib/const.lua
+++ b/modules/gamelib/const.lua
@@ -205,6 +205,7 @@ GameMapDrawGroundFirst = 116 -- useful for big auras & wings
 GameMapIgnoreCorpseCorrection = 117
 GameDontCacheFiles = 118 -- doesn't work with encryption and compression
 GameBigAurasCenter = 119 -- Automatic negative offset for aura bigger than 32x32
+GameNewUpdateWalk = 120 -- Walk update rate dependant on FPS
 
 LastGameFeature = 130
         

--- a/src/client/const.h
+++ b/src/client/const.h
@@ -479,6 +479,7 @@ namespace Otc
         GameMapIgnoreCorpseCorrection = 117,
         GameDontCacheFiles = 118,
         GameBigAurasCenter = 119,
+        GameNewUpdateWalk = 120,
 
         LastGameFeature = 130
     };

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -581,14 +581,18 @@ void Creature::nextWalkUpdate()
 void Creature::updateWalk()
 {
     float walkTicksPerPixel = getStepDuration(true) / 32.0f;
-    uint_fast16_t totalPixelsWalked = std::min<uint_fast16_t>(std::floor((m_walkTimer.ticksElapsed() / walkTicksPerPixel) + 0.5f), 32);
+    uint_fast8_t totalPixelsWalked = std::min<uint_fast8_t>(std::floor(m_walkTimer.ticksElapsed() / walkTicksPerPixel), 32);
+    uint_fast16_t frameLifetime = std::max<uint_fast16_t>(std::floor((1000.f / g_app.getFps()) + 0.5f), 1);
+    uint_fast8_t totalPixelsWalkedInNextFrame = std::min<uint_fast8_t>(std::floor((m_walkTimer.ticksElapsed() + frameLifetime) / walkTicksPerPixel), 32);
 
     // needed for paralyze effect
     m_walkedPixels = std::max<uint_fast16_t>(m_walkedPixels, totalPixelsWalked);
+    uint_fast8_t walkedPixelsInNextFrame = std::max<uint_fast8_t>(m_walkedPixels, totalPixelsWalkedInNextFrame);
 
     // update walk animation and offsets
     updateWalkAnimation(totalPixelsWalked);
     updateWalkOffset(m_walkedPixels);
+    updateWalkOffset(walkedPixelsInNextFrame, true);
     updateWalkingTile();
 
     // terminate walk
@@ -716,7 +720,7 @@ void Creature::updateOutfitColor(Color color, Color finalColor, Color delta, int
 
 void Creature::setSpeed(uint16 speed)
 {
-    uint16 oldSpeed = m_speed;
+    uint_fast16_t oldSpeed = m_speed;
     m_speed = speed;
 
     // speed can change while walking (utani hur, paralyze, etc..)
@@ -857,7 +861,7 @@ Point Creature::getDrawOffset()
 
 uint_fast16_t Creature::getStepDuration(bool ignoreDiagonal, Otc::Direction dir)
 {
-    int speed = m_speed;
+    uint_fast16_t speed = m_speed;
     if (speed < 1)
         return 0;
 

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -476,9 +476,9 @@ void Creature::updateWalkAnimation(int totalPixelsWalked)
 
     int footAnimPhases = getWalkAnimationPhases() - 1;
     // TODO, should be /2 for <= 810
-    uint16_t footDelay = getStepDuration(true);
+    uint_fast16_t footDelay = getStepDuration(true);
     if (footAnimPhases > 0) {
-        footDelay = std::ceil<uint16_t>((float)(getStepDuration(true)) / (g_game.getFeature(Otc::GameFasterAnimations) ? footAnimPhases * 2 : footAnimPhases));
+        footDelay = std::ceil<uint_fast16_t>((float)(getStepDuration(true)) / (g_game.getFeature(Otc::GameFasterAnimations) ? footAnimPhases * 2 : footAnimPhases));
     }
     if (!g_game.getFeature(Otc::GameFasterAnimations))
         footDelay += 10;
@@ -488,7 +488,7 @@ void Creature::updateWalkAnimation(int totalPixelsWalked)
     // Since mount is a different outfit we need to get the mount animation phases
     if (m_outfit.getMount() != 0) {
         ThingType* type = g_things.rawGetThingType(m_outfit.getMount(), m_outfit.getCategory());
-        footAnimPhases = std::min<uint16_t>(footAnimPhases, type->getAnimationPhases() - 1);
+        footAnimPhases = std::min<uint_fast16_t>(footAnimPhases, type->getAnimationPhases() - 1);
     }
 
     if (footAnimPhases == 0) {

--- a/src/client/creature.h
+++ b/src/client/creature.h
@@ -100,7 +100,7 @@ public:
     Otc::Direction getWalkDirection() { return m_walkDirection; }
     Outfit getOutfit() { return m_outfit; }
     Light getLight() { return m_light; }
-    uint_fast16_t getSpeed() { return m_speed; }
+    uint16 getSpeed() { return m_speed; }
     double getBaseSpeed() { return m_baseSpeed; }
     uint8 getSkull() { return m_skull; }
     uint8 getShield() { return m_shield; }
@@ -109,7 +109,7 @@ public:
     uint8 getIcon() { return m_icon; }
     bool isPassable() { return m_passable; }
     Point getDrawOffset();
-    uint_fast16_t getStepDuration(bool ignoreDiagonal = false, Otc::Direction dir = Otc::InvalidDirection);
+    uint16 getStepDuration(bool ignoreDiagonal = false, Otc::Direction dir = Otc::InvalidDirection);
     Point getWalkOffset(bool inNextFrame = false) { return inNextFrame ? m_walkOffsetInNextFrame : m_walkOffset; }
     Position getLastStepFromPosition() { return m_lastStepFromPosition; }
     Position getLastStepToPosition() { return m_lastStepToPosition; }
@@ -191,8 +191,8 @@ public:
     void updateProgressBar(uint32 duration, bool ltr);
 
 protected:
-    virtual void updateWalkAnimation(int totalPixelsWalked);
-    virtual void updateWalkOffset(int totalPixelsWalked, bool inNextFrame = false);
+    virtual void updateWalkAnimation(uint8 totalPixelsWalked);
+    virtual void updateWalkOffset(uint8 totalPixelsWalked, bool inNextFrame = false);
     void updateWalkingTile();
     virtual void nextWalkUpdate();
     virtual void updateWalk();
@@ -209,7 +209,7 @@ protected:
     Otc::Direction m_walkDirection;
     Outfit m_outfit;
     Light m_light;
-    uint_fast16_t m_speed;
+    uint16 m_speed;
     double m_baseSpeed;
     uint8 m_skull;
     uint8 m_shield;
@@ -242,7 +242,7 @@ protected:
 
     // walk related
     int m_walkAnimationPhase;
-    uint_fast8_t m_walkedPixels;
+    uint8 m_walkedPixels;
     uint m_footStep;
     Timer m_walkTimer;
     ticks_t m_footLastStep;
@@ -259,7 +259,7 @@ protected:
     Position m_lastStepToPosition;
     Position m_oldPosition;
     uint8 m_elevation = 0;
-    uint_fast16_t m_stepDuration = 0;
+    uint16 m_stepDuration = 0;
 
     // jump related
     float m_jumpHeight = 0;

--- a/src/client/creature.h
+++ b/src/client/creature.h
@@ -100,7 +100,7 @@ public:
     Otc::Direction getWalkDirection() { return m_walkDirection; }
     Outfit getOutfit() { return m_outfit; }
     Light getLight() { return m_light; }
-    uint16 getSpeed() { return m_speed; }
+    uint_fast16_t getSpeed() { return m_speed; }
     double getBaseSpeed() { return m_baseSpeed; }
     uint8 getSkull() { return m_skull; }
     uint8 getShield() { return m_shield; }
@@ -209,7 +209,7 @@ protected:
     Otc::Direction m_walkDirection;
     Outfit m_outfit;
     Light m_light;
-    int m_speed;
+    uint_fast16_t m_speed;
     double m_baseSpeed;
     uint8 m_skull;
     uint8 m_shield;

--- a/src/client/creature.h
+++ b/src/client/creature.h
@@ -242,7 +242,7 @@ protected:
 
     // walk related
     int m_walkAnimationPhase;
-    uint16_t m_walkedPixels;
+    uint_fast8_t m_walkedPixels;
     uint m_footStep;
     Timer m_walkTimer;
     ticks_t m_footLastStep;
@@ -259,7 +259,7 @@ protected:
     Position m_lastStepToPosition;
     Position m_oldPosition;
     uint8 m_elevation = 0;
-    uint16 m_stepDuration = 0;
+    uint_fast16_t m_stepDuration = 0;
 
     // jump related
     float m_jumpHeight = 0;

--- a/src/client/creature.h
+++ b/src/client/creature.h
@@ -109,7 +109,7 @@ public:
     uint8 getIcon() { return m_icon; }
     bool isPassable() { return m_passable; }
     Point getDrawOffset();
-    int getStepDuration(bool ignoreDiagonal = false, Otc::Direction dir = Otc::InvalidDirection);
+    uint_fast16_t getStepDuration(bool ignoreDiagonal = false, Otc::Direction dir = Otc::InvalidDirection);
     Point getWalkOffset(bool inNextFrame = false) { return inNextFrame ? m_walkOffsetInNextFrame : m_walkOffset; }
     Position getLastStepFromPosition() { return m_lastStepFromPosition; }
     Position getLastStepToPosition() { return m_lastStepToPosition; }
@@ -242,7 +242,7 @@ protected:
 
     // walk related
     int m_walkAnimationPhase;
-    int m_walkedPixels;
+    uint16_t m_walkedPixels;
     uint m_footStep;
     Timer m_walkTimer;
     ticks_t m_footLastStep;

--- a/src/client/localplayer.cpp
+++ b/src/client/localplayer.cpp
@@ -26,6 +26,7 @@
 #include "tile.h"
 #include <framework/core/eventdispatcher.h>
 #include <framework/graphics/graphics.h>
+#include <framework/core/application.h>
 #include <framework/util/extras.h>
 
 LocalPlayer::LocalPlayer()
@@ -367,14 +368,18 @@ void LocalPlayer::updateWalk()
         return;
 
     float walkTicksPerPixel = getStepDuration(true) / 32.0f;
-    uint_fast8_t totalPixelsWalked = std::min<uint_fast8_t>(std::floor((m_walkTimer.ticksElapsed() / walkTicksPerPixel) + 0.5f), 32);
+    uint_fast8_t totalPixelsWalked = std::min<uint_fast8_t>(std::floor(m_walkTimer.ticksElapsed() / walkTicksPerPixel), 32);
+    uint_fast16_t frameLifetime = std::max<uint_fast16_t>(std::floor((1000.f / g_app.getFps()) + 0.5f), 1);
+    uint_fast8_t totalPixelsWalkedInNextFrame = std::min<uint_fast8_t>(std::floor((m_walkTimer.ticksElapsed() + frameLifetime) / walkTicksPerPixel), 32);
 
     // needed for paralyze effect
     m_walkedPixels = std::max<uint_fast8_t>(m_walkedPixels, totalPixelsWalked);
+    uint_fast8_t walkedPixelsInNextFrame = std::max<uint_fast8_t>(m_walkedPixels, totalPixelsWalkedInNextFrame);
 
     // update walk animation and offsets
     updateWalkAnimation(totalPixelsWalked);
     updateWalkOffset(m_walkedPixels);
+    updateWalkOffset(walkedPixelsInNextFrame, true);
     updateWalkingTile();
 
     // terminate walk only when client and server side walk are completed

--- a/src/client/localplayer.h
+++ b/src/client/localplayer.h
@@ -149,7 +149,7 @@ protected:
     friend class Game;
 
 protected:
-    void updateWalkOffset(int totalPixelsWalked, bool inNextFrame = false) override;
+    void updateWalkOffset(uint8 totalPixelsWalked, bool inNextFrame = false) override;
     void updateWalk() override;
     void terminateWalk() override;
 


### PR DESCRIPTION
This PR attempts to solve https://github.com/OTCv8/otclientv8/issues/117
By calculating the offset for accurate `totalPixelsWalkedInNextFrame` in `updateWalk` and changing the walk update rate.
