### PR TITLE
Feature: New creature stacking

### DIFF
--- a/modules/gamelib/const.lua
+++ b/modules/gamelib/const.lua
@@ -206,6 +206,7 @@ GameMapIgnoreCorpseCorrection = 117
 GameDontCacheFiles = 118 -- doesn't work with encryption and compression
 GameBigAurasCenter = 119 -- Automatic negative offset for aura bigger than 32x32
 GameNewUpdateWalk = 120 -- Walk update rate dependant on FPS
+GameNewCreatureStacking = 121 -- Ignore MAX_THINGS limit while adding to tile
 
 LastGameFeature = 130
         

--- a/src/client/const.h
+++ b/src/client/const.h
@@ -480,6 +480,7 @@ namespace Otc
         GameDontCacheFiles = 118,
         GameBigAurasCenter = 119,
         GameNewUpdateWalk = 120,
+        GameNewCreatureStacking = 121,
 
         LastGameFeature = 130
     };

--- a/src/client/tile.cpp
+++ b/src/client/tile.cpp
@@ -304,7 +304,7 @@ void Tile::addThing(const ThingPtr& thing, int stackPos)
 
         m_things.insert(m_things.begin() + stackPos, thing);
 
-        if(m_things.size() > MAX_THINGS)
+        if(!g_game.getFeature(Otc::GameNewCreatureStacking) && m_things.size() > MAX_THINGS)
             removeThing(m_things[MAX_THINGS]);
 
         /*


### PR DESCRIPTION
This feature is a follow up to [tfs PR that fixed issues with stacking more than 10 creatures on one tile](https://github.com/otland/forgottenserver/pull/2673) 
