### PR TITLE
Fixed swapped soul/cap label

### DIFF
--- a/data/styles/40-inventory.otui
+++ b/data/styles/40-inventory.otui
@@ -194,12 +194,12 @@ InventoryWindow < MiniWindow
         margin-top: 3
 
       SoulCapLabel
-        id: soulLabel
+        id: capLabel
         anchors.top: slot10.bottom
         anchors.horizontalCenter: slot10.horizontalCenter
         
       SoulCapLabel
-        id: capLabel
+        id: soulLabel
         anchors.top: slot9.bottom
         anchors.horizontalCenter: slot9.horizontalCenter
 

--- a/layouts/retro/styles/40-inventory.otui
+++ b/layouts/retro/styles/40-inventory.otui
@@ -227,12 +227,12 @@ InventoryWindow < HeadlessMiniWindow
         margin-top: 3
 
       SoulCapLabel
-        id: soulLabel
+        id: capLabel
         anchors.top: slot10.bottom
         anchors.horizontalCenter: slot10.horizontalCenter
         
       SoulCapLabel
-        id: capLabel
+        id: soulLabel
         anchors.top: slot9.bottom
         anchors.horizontalCenter: slot9.horizontalCenter
 


### PR DESCRIPTION
Just a minor change, but it always bothered me, now they are like this:
![soulcap](https://user-images.githubusercontent.com/4684880/150659817-e47d9441-f045-444b-b7a5-5ae26dcfc8e2.png)

