### PR TITLE
fix - GameNewWalkUpdate scheduler delay bounds

### DIFF
--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -595,10 +595,10 @@ void Creature::nextWalkUpdate()
 	
     auto self = static_self_cast<Creature>();
     m_walkUpdateEvent = g_dispatcher.scheduleEvent([self]{
-            self->m_walkUpdateEvent = nullptr;
-            self->nextWalkUpdate();
-        }, g_game.getFeature(Otc::GameNewUpdateWalk) ? 
-            std::max(getStepDuration(true) / std::max(g_app.getFps(), 1), 1) : (float)getStepDuration() / g_sprites.spriteSize()
+        self->m_walkUpdateEvent = nullptr;
+        self->nextWalkUpdate();
+    }, g_game.getFeature(Otc::GameNewUpdateWalk) ? 
+        std::max(getStepDuration(true) / std::max(g_app.getFps(), 1), 1) : (float)getStepDuration() / g_sprites.spriteSize()
     );
 }
 

--- a/src/client/creature.cpp
+++ b/src/client/creature.cpp
@@ -589,14 +589,17 @@ void Creature::nextWalkUpdate()
     updateWalk();
 
     // schedules next update
-    if (m_walking) {
-        auto self = static_self_cast<Creature>();
-        m_walkUpdateEvent = g_dispatcher.scheduleEvent([self] {
+    if (!m_walking) {
+        return;
+    }
+	
+    auto self = static_self_cast<Creature>();
+    m_walkUpdateEvent = g_dispatcher.scheduleEvent([self]{
             self->m_walkUpdateEvent = nullptr;
             self->nextWalkUpdate();
-        }, g_game.getFeature(Otc::GameNewUpdateWalk) && isLocalPlayer() ?
-            std::ceil<uint16>(((float)getStepDuration(true) / g_app.getFps()) * 2) : (float)getStepDuration() / g_sprites.spriteSize());
-    }
+        }, g_game.getFeature(Otc::GameNewUpdateWalk) ? 
+            std::max(getStepDuration(true) / std::max(g_app.getFps(), 1), 1) : (float)getStepDuration() / g_sprites.spriteSize()
+    );
 }
 
 void Creature::updateWalk()


### PR DESCRIPTION
followup to https://github.com/OTCv8/otcv8-dev/pull/27

When the feature is enabled, this PR introduces `GameNewWalkUpdate` behavior for all screen creatures, it adds delay bounds to avoid scheduling updates too often, and to avoid possible division by 0 when `g_app.getFps()` returns it. 