### PR TITLE
Fixed game_topbar module path issue

### DIFF
--- a/modules/game_topbar/topbar.lua
+++ b/modules/game_topbar/topbar.lua
@@ -141,7 +141,7 @@ end
 
 function setupTopBar()
     local topPanel = modules.game_interface.getTopBar()
-    topBar = topBar or g_ui.loadUI('TopBar', topPanel)
+    topBar = topBar or g_ui.loadUI('topbar', topPanel)
     topBar = topBar or g_ui.createWidget('TopBar', topPanel)
 
     manaBar = topBar.stats.mana


### PR DESCRIPTION
This path is not resolved correctly on the Linux and Android clients. It affects client_profiles module functionality as the collective reload is affected.

```
ERROR: failed to load UI from 'TopBar.otui': unable to open file '/modules/game_topbar/TopBar.otui': not found
ERROR: failed to create widget from style 'TopBar': 'TopBar' is not a defined style
ERROR: protected lua call failed: /modules/game_topbar/topbar.lua:147: attempt to index upvalue 'topBar' (a nil value)
stack traceback:
    [C]: in function '__index'
    /modules/game_topbar/topbar.lua:147: in function 'setupTopBar'
    /modules/game_topbar/topbar.lua:160: in function </modules/game_topbar/topbar.lua:156>
```