### PR TITLE
VS 2022, boost asio update, fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ You can clone repoistory and use github action build-on-request workload.
 
 ### Windows
 
-You need visual studio 2019 and vcpkg with commit `3b3bd424827a1f7f4813216f6b32b6c61e386b2e` ([download](https://github.com/microsoft/vcpkg/archive/3b3bd424827a1f7f4813216f6b32b6c61e386b2e.zip)).
+You need visual studio 2022 and vcpkg with commit `3b3bd424827a1f7f4813216f6b32b6c61e386b2e` ([download](https://github.com/microsoft/vcpkg/archive/3b3bd424827a1f7f4813216f6b32b6c61e386b2e.zip)).
 
 Then you install vcpkg dependencies:
 ```bash

--- a/src/client/container.cpp
+++ b/src/client/container.cpp
@@ -68,7 +68,7 @@ void Container::onAddItem(const ItemPtr& item, int slot)
 
     if(slot == 0)
         m_items.push_front(item);
-    else
+    else if (slot > 0 && m_items.size() <= m_capacity - 1)
         m_items.push_back(item);
     updateItemsPositions();
 

--- a/src/client/outfit.cpp
+++ b/src/client/outfit.cpp
@@ -153,7 +153,21 @@ void Outfit::draw(Point dest, Otc::Direction direction, uint walkAnimationPhase,
             }
 
             dest -= mountType->getDisplacement() * g_sprites.getOffsetFactor();
-            mountType->draw(dest, 0, direction, 0, 0, mountAnimationPhase, Color::white, lightView);
+            if (type->hasBones() && mountType->hasBones()) {
+                auto mountDest = dest;
+                auto outfitBones = type->getBones(direction);
+                auto outfitWidth = type->getWidth();
+                auto mountWidth = mountType->getWidth();
+                int bonusOffset = std::abs(mountWidth - outfitWidth) * 32;
+                auto mountBones = mountType->getBones(direction);
+                auto boneOffset = Point((outfitBones.x - mountBones.x) + bonusOffset, (outfitBones.y - mountBones.y) + bonusOffset);
+
+                mountDest = dest + boneOffset * g_sprites.getOffsetFactor();
+                mountType->draw(mountDest, 0, direction, 0, 0, mountAnimationPhase, Color::white, lightView);
+            }
+            else {
+                mountType->draw(dest, 0, direction, 0, 0, mountAnimationPhase, Color::white, lightView);
+            }
             dest += type->getDisplacement() * g_sprites.getOffsetFactor();
         }
     };

--- a/src/framework/graphics/drawqueue.cpp
+++ b/src/framework/graphics/drawqueue.cpp
@@ -253,6 +253,7 @@ void DrawQueue::correctOutfit(const Rect& dest, int fromPos, bool oldScaling)
 
                 if (texture->m_doCenter) {
                     centerX = std::max<int>(centerX, texture->m_dest.center().x);
+                    centerY = std::max<int>(centerY, texture->m_dest.center().y);
                 }
             }
             else if (DrawQueueItemTexturedRect* texture = dynamic_cast<DrawQueueItemTexturedRect*>(m_queue[i])) {

--- a/src/framework/net/connection.cpp
+++ b/src/framework/net/connection.cpp
@@ -162,7 +162,7 @@ void Connection::read(uint32 bytes, const RecvCallback& callback)
     m_recvCallback = callback;
 
     asio::async_read(m_socket,
-                     asio::buffer(m_inputStream.prepare(bytes)),
+                     asio::mutable_buffer(m_inputStream.prepare(bytes)),
                      std::bind(&Connection::onRecv, asConnection(), std::placeholders::_1, std::placeholders::_2));
 
     m_readTimer.cancel();
@@ -194,7 +194,7 @@ void Connection::read_some(const RecvCallback& callback)
 
     m_recvCallback = callback;
 
-    m_socket.async_read_some(asio::buffer(m_inputStream.prepare(RECV_BUFFER_SIZE)),
+    m_socket.async_read_some(asio::mutable_buffer(m_inputStream.prepare(RECV_BUFFER_SIZE)),
                              std::bind(&Connection::onRecv, asConnection(), std::placeholders::_1, std::placeholders::_2));
 
     m_readTimer.cancel();

--- a/vc16/otclient.vcxproj
+++ b/vc16/otclient.vcxproj
@@ -31,7 +31,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='OpenGL|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <WholeProgramOptimization>PGOptimize</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
@@ -39,7 +39,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='DirectX|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <WholeProgramOptimization>PGOptimize</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
@@ -47,7 +47,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug_lib|Win32'" Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
@@ -55,7 +55,7 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <WholeProgramOptimization>false</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>


### PR DESCRIPTION
* Updated project to VS 2022
* Updated boost asio to use mutable buffer
* Added missing outfit centering on Y axis
* Added bones support for mounts
* Fixed container with pagination not updating items correctly