### PR TITLE
Make outputMessage::addRawString available in Lua

### DIFF
--- a/src/framework/luafunctions.cpp
+++ b/src/framework/luafunctions.cpp
@@ -898,6 +898,7 @@ void Application::registerLuaFunctions()
     g_lua.bindClassMemberFunction<OutputMessage>("addU32", &OutputMessage::addU32);
     g_lua.bindClassMemberFunction<OutputMessage>("addU64", &OutputMessage::addU64);
     g_lua.bindClassMemberFunction<OutputMessage>("addString", &OutputMessage::addString);
+    g_lua.bindClassMemberFunction<OutputMessage>("addRawString", &OutputMessage::addRawString);
     g_lua.bindClassMemberFunction<OutputMessage>("addPaddingBytes", &OutputMessage::addPaddingBytes);
     g_lua.bindClassMemberFunction<OutputMessage>("encryptRsa", &OutputMessage::encryptRsa);
     g_lua.bindClassMemberFunction<OutputMessage>("getMessageSize", &OutputMessage::getMessageSize);


### PR DESCRIPTION
Why write
```lua
msg:addU8(1);
msg:addU8(0);
msg:addU8(113);
```
when you can instead write
```lua
msg:addRawString("\x01\x00\x71");
```
? Would make some lua scripts much easier to write :)