### PR TITLE
Make Container::findItemById available in lua

### DIFF
--- a/src/client/luafunctions_client.cpp
+++ b/src/client/luafunctions_client.cpp
@@ -396,6 +396,7 @@ void Client::registerLuaFunctions()
     g_lua.bindClassMemberFunction<Container>("hasPages", &Container::hasPages);
     g_lua.bindClassMemberFunction<Container>("getSize", &Container::getSize);
     g_lua.bindClassMemberFunction<Container>("getFirstIndex", &Container::getFirstIndex);
+    g_lua.bindClassMemberFunction<Container>("findItemById", &Container::findItemById);
 
     g_lua.registerClass<Thing>();
     g_lua.bindClassMemberFunction<Thing>("setId", &Thing::setId);


### PR DESCRIPTION
Previously if you wanted to check if a specific container had a specific id, you would need to iterate the container manually.