### PR TITLE
port g_resources::getRealDir from edubart/otclient

### DIFF
--- a/src/framework/core/resourcemanager.cpp
+++ b/src/framework/core/resourcemanager.cpp
@@ -1146,3 +1146,13 @@ void ResourceManager::unmountMemoryData()
     m_loadedFromMemory = false;
     m_loadedFromArchive = false;
 }
+
+
+std::string ResourceManager::getRealDir(const std::string& path)
+{
+    std::string dir;
+    const char *cdir = PHYSFS_getRealDir(resolvePath(path).c_str());
+    if(cdir)
+        dir = cdir;
+    return dir;
+}

--- a/src/framework/core/resourcemanager.h
+++ b/src/framework/core/resourcemanager.h
@@ -64,6 +64,7 @@ public:
     std::list<std::string> listDirectoryFiles(const std::string & directoryPath = "", bool fullPath = false, bool raw = false);
 
     std::string resolvePath(std::string path);
+    std::string getRealDir(const std::string& path);
     std::string getWorkDir() { return "/"; }
 #ifdef ANDROID
     std::string getWriteDir() { return "/"; }

--- a/src/framework/luafunctions.cpp
+++ b/src/framework/luafunctions.cpp
@@ -264,6 +264,7 @@ void Application::registerLuaFunctions()
     g_lua.bindSingletonFunction("g_resources", "decompressArchive", &ResourceManager::decompressArchive, &g_resources);
     g_lua.bindSingletonFunction("g_resources", "setLayout", &ResourceManager::setLayout, &g_resources);
     g_lua.bindSingletonFunction("g_resources", "getLayout", &ResourceManager::getLayout, &g_resources);
+    g_lua.bindSingletonFunction("g_resources", "getRealDir", &ResourceManager::getRealDir, &g_resources);
 
     // Config
     g_lua.registerClass<Config>();


### PR DESCRIPTION
Finds the dir of a specified file, more detailed documentation at https://icculus.org/physfs/docs/html/physfs_8h.html#a539bcf0ebde6271e3e4a90dd287ca975

This increase scripting compatibiliity with edubrt/otclient, and is required by CandyBot:
http://bendol.github.io/otclient-candybot/

fixes CandyBot crash 
> attempt to call field getRealDir (a nil value)